### PR TITLE
Fix geocolumn bug

### DIFF
--- a/superset/assets/src/dashboard/actions/dashboardState.js
+++ b/superset/assets/src/dashboard/actions/dashboardState.js
@@ -29,8 +29,10 @@ export function setUnsavedChanges(hasUnsavedChanges) {
 export const CHANGE_FILTER = 'CHANGE_FILTER';
 export function changeFilter(chart, col, vals, merge = true, refresh = true, operation = "in") {
   let op = operation;
+  var tableId = chart.formData.datasource;
   if (chart.formData.geofilterable === true) {
     op = 'geo_within';
+    col = tableId + '.' + col
   }
   Logger.append(LOG_ACTIONS_CHANGE_DASHBOARD_FILTER, {
     id: chart.id,

--- a/superset/assets/src/visualizations/FilterBox/FilterBox.jsx
+++ b/superset/assets/src/visualizations/FilterBox/FilterBox.jsx
@@ -180,7 +180,14 @@ class FilterBox extends React.Component {
   renderFilters() {
     const { filtersFields, filtersChoices } = this.props;
     const { selectedValues } = this.state;
-
+    //Undo concat of table_name.column_name as a key in filter
+    Object.keys(selectedValues)
+        .filter(key => key.includes('.'))
+        .map(key => {
+              let new_key = key.split('.')[1];
+              selectedValues[new_key] = selectedValues[key];
+          delete selectedValues[key]}
+          );
     // Add created options to filtersChoices, even though it doesn't exist,
     // or these options will exist in query sql but invisible to end user.
     Object.keys(selectedValues)


### PR DESCRIPTION
Our geocolumn feature was depending only on picked column names. This may be misleading as we might want to keep different geoshapes files for various location columns.
The following solution has been implemented:
For `geo_within` operation we concatenate jsx table_id to column name in filter: `col = table_4.oblast`.
Then by string operations in `modules.py` we can retrieve filter "originating" table id. Also in `FilterBox.jsx` render part we need to undo the concatenation operation.

I was trying to came up with sth smarter but extending filter object from `{col: 'Oblast', op: 'geo_within', val: ['Donetsk'], tableId: '4'}` required way to deep modification in superset core and hence not worth it IMO. @Gulfa It'd be great if you could review it post factum.